### PR TITLE
Add agency column to payload and switch to oracle package install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM atddocker/atd-oracle-py:production
+FROM python:3.8-slim
 
 # Copy our own application
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -10,13 +10,11 @@ The script `main.py` contained in this repo bypasses the RSS feed and instead co
 
 ### Automation
 
-The `main.py` script is scheduled to run every 5 minutes by [Airflow](https://github.com/cityofaustin/atd-airflow/blob/production/dags/atd_traffic_incident_reports.py).
-
-The data from the postgrest database is pushed to socrata [every 5 minutes as well](https://github.com/cityofaustin/atd-data-deploy/blob/production/config/scripts.yml#L279).
+The `main.py` and `records_to_socrata.py` scripts are scheduled to run every 5 minutes by [Airflow](https://github.com/cityofaustin/atd-airflow/blob/production/dags/atd_traffic_incident_reports.py).
 
 ### Setup
 
-The easiest path to running these utilities locally is to build this repo's Docker image, or pull it from `atddocker/atd-traffic-incident-reports`. This container builds on top of `atd-oracle-py`, which solves the headache of installing `cx_Oracle`. Any push to the main branch will trigger a docker build/push to Docker hub, updating the atd-traffic-incident-reports Docker image.
+The easiest path to running these utilities locally is to build this repo's Docker image, or pull it from `atddocker/atd-traffic-incident-reports`. Previous versions of this code depended on cx_Oracle, it now uses [oracledb](https://python-oracledb.readthedocs.io/en/latest/user_guide/appendix_c.html#steps-to-upgrade-to-python-oracledb). Any push to the main branch will trigger a docker build/push to Docker hub, updating the atd-traffic-incident-reports Docker image.
 
 This repo has a `template.env` file, copy that file and rename as `.env`. The missing credentials can be found in the DTS 1Password vault, search "Austin-Travis County Traffic Report" for the username and password. The postgrest token is the legacy-scripts token.
 

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import os
 import logging
 import sys
 import requests
-import cx_Oracle
+import oracledb as cx_Oracle
 import hashlib
 import arrow
 
@@ -161,8 +161,10 @@ def main():
     logging.info(f"{len(payload)} records to upsert into postgrest.")
 
     if payload:
-        res = requests.post(PGREST_ENDPOINT, headers=headers, json=payload)
+        res = requests.post(f"{PGREST_ENDPOINT}/traffic_reports", headers=headers, json=payload)
         logging.info(f"request response status code: {res.status_code}")
+        if res.status_code == 400:
+            logging.info(res.text)
         return res.json()
 
 

--- a/main.py
+++ b/main.py
@@ -101,6 +101,7 @@ def format_record(incident):
     record["issue_reported"] = incident['DESCRIPTION'].strip()
     record["latitude"] = incident['LATITUDE']
     record["longitude"] = incident['LONGITUDE']
+    record["agency"] = incident['AGENCY_TYPE']
     return record
 
 

--- a/main.py
+++ b/main.py
@@ -78,7 +78,6 @@ def get_active_records():
     :return: list of active records (dict)
     """
     active_records_endpoint = f"{PGREST_ENDPOINT}/traffic_reports?traffic_report_status=eq.ACTIVE"
-
     active_records_response = requests.get(active_records_endpoint, headers=headers)
     active_records_response.raise_for_status()
     return active_records_response.json()
@@ -163,8 +162,7 @@ def main():
     if payload:
         res = requests.post(f"{PGREST_ENDPOINT}/traffic_reports", headers=headers, json=payload)
         logging.info(f"request response status code: {res.status_code}")
-        if res.status_code == 400:
-            logging.info(res.text)
+        res.raise_for_status()
         return res.json()
 
 

--- a/records_to_postgrest.py
+++ b/records_to_postgrest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # docker run -it --rm --env-file .env -v /path/to/folder/atd-traffic-incident-reports:/app \
-# atddocker/atd-traffic-incident-reports:production python main.py
+# atddocker/atd-traffic-incident-reports:production python records_to_postgrest.py
 
 import os
 import logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-# this library requires the cx_Oracle package, but we source it from our
-# ready-made Oracle docker container: https://github.com/cityofaustin/atd-oracle-py
 arrow==1.2.*
 requests==2.28.*
 sodapy==2.1.*
 pypgrest==0.1.*
+oracledb==2.0.*


### PR DESCRIPTION
https://github.com/cityofaustin/atd-data-tech/issues/12590
I opened this in December to add the column to the payload, I added the column to the postgrest database in anticipation. I incorrectly thought that it was being ignored by socrata until it was explicitly added to the payload. 

But Charlie discovered that it was breaking socrata. He fixed it by adding the column to the socrata data set. 

As to the drop in incidents since December, I have tried to see if the additional column would somehow "fail silently" or prevent data from being saved in postgrest. But every record does have agency populated, so I dont understand how it would be preventing data from being ingested....

here is what the oracle db looks like
![Screenshot 2024-01-24 at 9 09 27 AM](https://github.com/cityofaustin/atd-traffic-incident-reports/assets/12474808/eb96bf0e-535a-4419-b186-0c95656e595b)

test by building a new docker image on your machine (i changed the dockerfile) or start a virtual env and use that. lemme know if you want me to wormhole you a .env file
