### PR TITLE
Populate location column with build_point_data

### DIFF
--- a/records_to_socrata.py
+++ b/records_to_socrata.py
@@ -49,8 +49,12 @@ def main(args):
     client_socrata = utils.socrata.get_client()
     method = "replace" if not args.date else "upsert"
 
-    utils.socrata.publish(method=method, resource_id=SOCRATA_RESOURCE_ID, payload=data, client=client_socrata
-                          )
+    utils.socrata.publish(
+        method=method,
+        resource_id=SOCRATA_RESOURCE_ID,
+        payload=data,
+        client=client_socrata,
+    )
     logger.info(f"{len(data)} records processed.")
 
 


### PR DESCRIPTION
Changed the datatype of text `location` column so now it's expecting a formatted [point datatype](https://dev.socrata.com/docs/datatypes/point.html). 

So now we can make gripping visualizations such as:
<img width="695" alt="Screenshot 2024-01-26 at 2 14 03 PM" src="https://github.com/cityofaustin/atd-traffic-incident-reports/assets/30810522/91507002-885f-41de-8e8f-91b510a29254">

Reminder to re-process all of the historical data after we merge this as the records made after this PR will not have this location column populated.