### PR TITLE
Fire incidents sometimes not updating in Socrata

### DIFF
--- a/records_to_socrata.py
+++ b/records_to_socrata.py
@@ -61,7 +61,7 @@ def main(args):
         logger.info(f"{len(data)} {dataset}s to process")
 
         if not data:
-            return
+            continue
 
         build_point_data(data)
 


### PR DESCRIPTION
@chiaberry found that some incidents were staying "ACTIVE" in the socrata [dataset](https://datahub.austintexas.gov/Public-Safety/Real-Time-Fire-Incidents/wpu4-x69d/about_data). I checked our postgres DB and found these were all "ARCHIVED".

Basically when refactoring this code I introduced a bug where if there's no traffic incidents to update then it will skip checking for fire incidents. This should fix that.

I'll do a rerun of the records_to_socrata script locally with a date in the way past once this is merged and we should be back in sync with the DB 👍 